### PR TITLE
Add Camera.Up support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ Blazor component that displays 3D things :)
 Blazor + ThreeJS = Blazor3D
 
 You can find the documentation and examples of using Blazor3D [here](https://github.com/HomagGroup/Blazor3D)
+
+## Build Instructions
+### Build the Javascript bundle using webpack
+* From a node.js command prompt, navigate to `Blazor3D-Core\src\javascript`
+* Run `npx webpack --mode production`
+* A `bundle.js` will be created inside `Blazor3D-Core\src\dotnet\Blazor3D\Blazor3D\wwwroot\js` which Blazor can reference
+
+### Build the dotnet assembly 
+* Build the csproj from VSCode or Visual Studio
+* `dotnet pack` to package into a `nupkg`

--- a/doc/HomagGroup.Blazor3D.xml
+++ b/doc/HomagGroup.Blazor3D.xml
@@ -21,6 +21,12 @@
             The point camera looks at.
             </summary>
         </member>
+        <member name="P:HomagGroup.Blazor3D.Cameras.Camera.Up">
+            <summary>
+            This is used by the LookAt method, for example, to determine the orientation of the result.
+            Default is ( 0, 1, 0 ).
+            </summary>
+        </member>
         <member name="T:HomagGroup.Blazor3D.Cameras.OrthographicCamera">
             <summary>
             <para>Camera that uses <a target="_blank" href="https://en.wikipedia.org/wiki/Orthographic_projection">orthographic projection</a>.</para>

--- a/src/dotnet/Blazor3D/Blazor3D.Tests/Cameras/OrthographicCameraTests.cs
+++ b/src/dotnet/Blazor3D/Blazor3D.Tests/Cameras/OrthographicCameraTests.cs
@@ -19,6 +19,7 @@ namespace HomagGroup.Blazor3D.Tests.Cameras
             Assert.AreEqual(1, camera.Zoom);
             Assert.IsNotNull(camera.AnimateRotationSettings);
             Assert.IsNotNull(camera.LookAt);
+            Assert.IsNotNull(camera.Up);
         }
 
         [TestMethod]

--- a/src/dotnet/Blazor3D/Blazor3D/Cameras/Camera.cs
+++ b/src/dotnet/Blazor3D/Blazor3D/Cameras/Camera.cs
@@ -24,5 +24,13 @@ namespace HomagGroup.Blazor3D.Cameras
         /// The point camera looks at.
         /// </summary>
         public Vector3 LookAt { get; set; } = new Vector3();
+
+
+        /// <summary>
+        /// This is used by the LookAt method, for example, to determine the orientation of the result.
+        /// Default is ( 0, 1, 0 ).
+        /// </summary>
+        public Vector3 Up { get; set; } = new Vector3(0, 1, 0);
+
     }
 }

--- a/src/javascript/Builders/CameraBuilder.js
+++ b/src/javascript/Builders/CameraBuilder.js
@@ -30,6 +30,7 @@ class CameraBuilder {
     Transforms.setPosition(camera, options.position);
     Transforms.setRotation(camera, options.rotation);
     Transforms.setScale(camera, options.scale);
+    camera.up = new THREE.Vector3(options.up.x, options.up.y, options.up.z);
     let {x, y, z} = options.lookAt;
     camera.lookAt(x, y, z);
     return camera;


### PR DESCRIPTION
* Allows for proper camera control where the coordinate system is not aligned with [`Object3D.DEFAULT_UP`](https://threejs.org/docs/index.html#api/en/core/Object3D.DEFAULT_UP)
* Added some build instructions to `README.md` as I had a hard time working out how to build it :) 