### PR TITLE
Import3DModelFileAsync method Added

### DIFF
--- a/doc/HomagGroup.Blazor3D.xml
+++ b/doc/HomagGroup.Blazor3D.xml
@@ -1966,6 +1966,16 @@
             <param name="settings"><see cref="T:HomagGroup.Blazor3D.Settings.ImportSettings"/> Settings that will be applied during 3D model file importing.</param>
             <returns>Guid of the loaded item</returns>
         </member>
+        <member name="M:HomagGroup.Blazor3D.Viewers.Viewer.Import3DModelFileAsync(System.String,HomagGroup.Blazor3D.Materials.MeshStandardMaterial,System.String,System.Nullable{System.Guid})">
+            <summary>
+            <para>Imports 3D model file to scene.</para>
+            </summary>
+            <param name="fileUrl">URL of the 3D model file.</param>
+            <param name="material"><see cref="T:HomagGroup.Blazor3D.Materials.MeshStandardMaterial"/>Material that will be applied to all loaded meshes.</param>
+            <param name="textureUrl">URL of the texture file.</param>
+            <param name="Uuid">UUID of the object to be loaded. Nullable. If not specified, the new Guid is genrated.</param>
+            <returns>Guid of the loaded item</returns>
+        </member>
         <member name="M:HomagGroup.Blazor3D.Viewers.Viewer.ImportSpriteAsync(HomagGroup.Blazor3D.Settings.SpriteImportSettings)">
             <summary>
             <para>Imports sprite to scene.</para>

--- a/src/dotnet/Blazor3D/Blazor3D/Viewers/Viewer.razor.cs
+++ b/src/dotnet/Blazor3D/Blazor3D/Viewers/Viewer.razor.cs
@@ -13,6 +13,7 @@ using HomagGroup.Blazor3D.Events;
 using Newtonsoft.Json.Linq;
 using HomagGroup.Blazor3D.Core;
 using HomagGroup.Blazor3D.Materials;
+using HomagGroup.Blazor3D.Enums;
 
 namespace HomagGroup.Blazor3D.Viewers
 {
@@ -237,6 +238,40 @@ namespace HomagGroup.Blazor3D.Viewers
             var json = JsonConvert.SerializeObject(settings, SerializationHelper.GetSerializerSettings());
             await bundleModule.InvokeVoidAsync("import3DModel", json);
             return settings.Uuid.Value;
+        }
+
+        /// <summary>
+        /// <para>Imports 3D model file to scene.</para>
+        /// </summary>
+        /// <param name="fileUrl">URL of the 3D model file.</param>
+        /// <param name="material"><see cref="MeshStandardMaterial"/>Material that will be applied to all loaded meshes.</param>
+        /// <param name="textureUrl">URL of the texture file.</param>
+        /// <param name="Uuid">UUID of the object to be loaded. Nullable. If not specified, the new Guid is genrated.</param>
+        /// <returns>Guid of the loaded item</returns>
+        public async Task<Guid> Import3DModelFileAsync(string fileUrl, MeshStandardMaterial? material = null, string? textureUrl = null, Guid? Uuid = null)
+        {
+            var settings = new ImportSettings()
+            {
+                FileURL = fileUrl,
+                Format = fileUrl.Split('.')[1].ToLower() switch
+                {
+                    "stl" => Import3DFormats.Stl,
+                    "obj" => Import3DFormats.Obj,
+                    "gltf" => Import3DFormats.Gltf,
+                    "glb" => Import3DFormats.Gltf,
+                    "dae" => Import3DFormats.Collada,
+                    "fbx" => Import3DFormats.Fbx,
+                    _ => Import3DFormats.Obj
+                }
+            };
+
+            if (material is not null) settings.Material = material;
+
+            if (textureUrl is not null) settings.TextureURL = textureUrl;
+
+            if (Uuid is not null) settings.Uuid = Uuid;
+
+            return Import3DModelAsync(settings);
         }
 
         /// <summary>

--- a/src/dotnet/Blazor3D/Blazor3D/Viewers/Viewer.razor.cs
+++ b/src/dotnet/Blazor3D/Blazor3D/Viewers/Viewer.razor.cs
@@ -271,7 +271,7 @@ namespace HomagGroup.Blazor3D.Viewers
 
             if (Uuid is not null) settings.Uuid = Uuid;
 
-            return Import3DModelAsync(settings);
+            return await Import3DModelAsync(settings);
         }
 
         /// <summary>


### PR DESCRIPTION
To improve the loading model by checking the file extension detection.

Example:

`loadedObjectGuid = await view3D.Import3DModelFileAsync("/Assets/Models/uploads_files_2270154_tajmahal.STL");`